### PR TITLE
send the environment in the auth requests if available

### DIFF
--- a/fh-ios-sdk/FH.m
+++ b/fh-ios-sdk/FH.m
@@ -143,7 +143,7 @@ static Reachability *reachability;
         act.method = FH_ACT;
         break;
     case FH_ACTION_AUTH:
-        act = [[FHAuthRequest alloc] init];
+        act = [[FHAuthRequest alloc] initWithProps:cloudProps];
         act.method = FH_AUTH;
         break;
     case FH_ACTION_CLOUD:

--- a/fh-ios-sdk/FHAct.h
+++ b/fh-ios-sdk/FHAct.h
@@ -82,6 +82,11 @@
 */
 - (BOOL)isAsync;
 
+/** Init a new request and set the FHCloudProps
+ @param props the cloud app details
+ */
+- (instancetype)initWithProps:(FHCloudProps *)props;
+
 /** Excute the API request synchronously with the given success and failure
 blocks.
 

--- a/fh-ios-sdk/FHAct.m
+++ b/fh-ios-sdk/FHAct.m
@@ -24,6 +24,14 @@
     return self;
 }
 
+- (instancetype)initWithProps:(FHCloudProps *)props {
+    self = [super init];
+    if (self) {
+        _cloudProps = props;
+    }
+    return self;
+}
+
 - (void)setArgs:(NSDictionary *)arguments {
     _args = [NSMutableDictionary dictionaryWithDictionary:arguments];
     NSLog(@"args set to  %@", _args);

--- a/fh-ios-sdk/FHActRequest.h
+++ b/fh-ios-sdk/FHActRequest.h
@@ -15,6 +15,4 @@
 /** The cloud side function name */
 @property (nonatomic, strong) NSString *remoteAction;
 
-- (instancetype)initWithProps:(FHCloudProps *)props;
-
 @end

--- a/fh-ios-sdk/FHActRequest.m
+++ b/fh-ios-sdk/FHActRequest.m
@@ -9,14 +9,6 @@
 #import "FH.h"
 @implementation FHActRequest
 
-- (instancetype)initWithProps:(FHCloudProps *)props {
-    self = [super init];
-    if (self) {
-        _cloudProps = props;
-    }
-    return self;
-}
-
 - (NSURL *)buildURL {
     NSString *cloudUrl = _cloudProps.cloudHost;
     NSString *api = [cloudUrl stringByAppendingString:self.path];

--- a/fh-ios-sdk/FHAuthRequest.h
+++ b/fh-ios-sdk/FHAuthRequest.h
@@ -40,11 +40,6 @@ See parentViewController.
 */
 - (instancetype)initWithViewController:(UIViewController *)viewController;
 
-/** Init a new request and set the FHCloudProps 
- @param props the cloud app details
- */
-- (instancetype)initWithProps:(FHCloudProps *)props;
-
 /** Set the policyId for this auth request.
 
 Normally should be used if the auth type is OAuth.

--- a/fh-ios-sdk/FHAuthRequest.h
+++ b/fh-ios-sdk/FHAuthRequest.h
@@ -35,12 +35,15 @@ handle the OAuth process.
 @property (nonatomic, strong) UIViewController *parentViewController;
 
 /** Init a new request and set the parentViewController.
-
-@param props The app configurations
 @param viewController The parent UIViewController to present OAuth UI component.
 See parentViewController.
 */
 - (instancetype)initWithViewController:(UIViewController *)viewController;
+
+/** Init a new request and set the FHCloudProps 
+ @param props the cloud app details
+ */
+- (instancetype)initWithProps:(FHCloudProps *)props;
 
 /** Set the policyId for this auth request.
 

--- a/fh-ios-sdk/FHAuthRequest.m
+++ b/fh-ios-sdk/FHAuthRequest.m
@@ -24,14 +24,6 @@
     return self;
 }
 
-- (instancetype)initWithProps:(FHCloudProps *)props {
-    self = [super init];
-    if (self) {
-        _cloudProps = props;
-    }
-    return self;
-}
-
 - (NSString *)path {
     return FH_AUTH_PATH;
 }
@@ -66,7 +58,7 @@
     }
 
     [params setValue:innerP forKey:@"params"];
-    if (nil != _cloudProps.env) {
+    if (_cloudProps &&  _cloudProps.env) {
         [params setValue:_cloudProps.env forKey:@"environment"];
     }
     _args = params;

--- a/fh-ios-sdk/FHAuthRequest.m
+++ b/fh-ios-sdk/FHAuthRequest.m
@@ -24,6 +24,14 @@
     return self;
 }
 
+- (instancetype)initWithProps:(FHCloudProps *)props {
+    self = [super init];
+    if (self) {
+        _cloudProps = props;
+    }
+    return self;
+}
+
 - (NSString *)path {
     return FH_AUTH_PATH;
 }
@@ -58,6 +66,9 @@
     }
 
     [params setValue:innerP forKey:@"params"];
+    if (nil != _cloudProps.env) {
+        [params setValue:_cloudProps.env forKey:@"environment"];
+    }
     _args = params;
     NSLog(@"args set to  %@", _args);
     return;

--- a/fh-ios-sdk/FHCloudProps.h
+++ b/fh-ios-sdk/FHCloudProps.h
@@ -9,6 +9,7 @@
 
 @property (nonatomic, strong, readonly) NSDictionary *cloudProps;
 @property (nonatomic, strong, readonly) NSString *cloudHost;
+@property (nonatomic, strong, readonly) NSString *env;
 
 - (instancetype)initWithCloudProps:(NSDictionary *)aCloudProps;
 

--- a/fh-ios-sdk/FHCloudProps.m
+++ b/fh-ios-sdk/FHCloudProps.m
@@ -18,9 +18,6 @@
 
 @implementation FHCloudProps
 
-@synthesize cloudHost = _cloudHost;
-@synthesize env =_env;
-
 - (instancetype)initWithCloudProps:(NSDictionary *)aCloudProps {
     self = [super init];
     if (self) {

--- a/fh-ios-sdk/FHCloudProps.m
+++ b/fh-ios-sdk/FHCloudProps.m
@@ -12,12 +12,14 @@
 
 @property (nonatomic, strong, readwrite) NSDictionary *cloudProps;
 @property (nonatomic, strong, readwrite) NSString *cloudHost;
+@property (nonatomic, strong, readwrite) NSString *env;
 
 @end
 
 @implementation FHCloudProps
 
 @synthesize cloudHost = _cloudHost;
+@synthesize env =_env;
 
 - (instancetype)initWithCloudProps:(NSDictionary *)aCloudProps {
     self = [super init];
@@ -51,6 +53,15 @@
         _cloudHost = api;
     }
     return _cloudHost;
+}
+
+- (NSString *)env {
+    if (nil == _env) {
+        if (self.cloudProps[@"hosts"] && self.cloudProps[@"hosts"][@"environment"]) {
+            _env = self.cloudProps[@"hosts"][@"environment"];
+        }
+    }
+    return _env;
 }
 
 @end

--- a/fh-ios-sdk/FHCloudRequest.h
+++ b/fh-ios-sdk/FHCloudRequest.h
@@ -9,6 +9,4 @@
 
 @interface FHCloudRequest : FHAct
 
-- (instancetype)initWithProps:(FHCloudProps *)props;
-
 @end

--- a/fh-ios-sdk/FHCloudRequest.m
+++ b/fh-ios-sdk/FHCloudRequest.m
@@ -10,14 +10,6 @@
 
 @implementation FHCloudRequest
 
-- (instancetype)initWithProps:(FHCloudProps *)props {
-    self = [super init];
-    if (self) {
-        _cloudProps = props;
-    }
-    return self;
-}
-
 - (NSURL *)buildURL {
     NSString *cloudUrl = _cloudProps.cloudHost;
 


### PR DESCRIPTION
When FH.auth is called, the environment value should be sent in the request as well if it is available in the CloudProps.