### PR TITLE
refactor so the designated initializer is called on parent:init

### DIFF
--- a/fh-ios-sdk/FHAct.m
+++ b/fh-ios-sdk/FHAct.m
@@ -13,22 +13,20 @@
 @implementation FHAct
 
 - (instancetype)init {
-    self = [super init];
-    if (self) {
-        _args = [NSMutableDictionary dictionary];
-        _httpClient = [[FHHttpClient alloc] init];
-        _headers = [NSMutableDictionary dictionary];
-        self.requestMethod = @"POST";
-        self.requestTimeout = 60;
-    }
-    return self;
+    return [self initWithProps:nil];
 }
 
 - (instancetype)initWithProps:(FHCloudProps *)props {
     self = [super init];
     if (self) {
         _cloudProps = props;
+        _args = [NSMutableDictionary dictionary];
+        _httpClient = [[FHHttpClient alloc] init];
+        _headers = [NSMutableDictionary dictionary];
+        self.requestMethod = @"POST";
+        self.requestTimeout = 60;
     }
+    
     return self;
 }
 


### PR DESCRIPTION
Motivation:
since [initWithProps] has been promoted as the designated initialiser from this PR https://github.com/feedhenry/fh-ios-sdk/pull/27, refactor plain init to call it instead. This fixes an issue where the _httpclient is not constructed at the point of call.

@wei-lee mind to review and release a new cocoa version?
