### PR TITLE
use specific types on completionHandler response instead of id

### DIFF
--- a/fh-ios-sdk/FH.h
+++ b/fh-ios-sdk/FH.h
@@ -46,7 +46,7 @@ best way to do it is using the success block.
 @param sucornil Block to be called if init is successful. It could be nil.
 @param failornil Block to be called if init is failed. It could be nil.
 */
-+ (void)initWithSuccess:(void (^)(id success))sucornil AndFailure:(void (^)(id failed))failornil;
++ (void)initWithSuccess:(void (^)(FHResponse *success))sucornil AndFailure:(void (^)(FHResponse *failed))failornil;
 
 /** Check if the device is online. The device is online if either WIFI or 3G
 network is available.
@@ -98,8 +98,8 @@ function is failed
 */
 + (void)performActRequest:(NSString *)funcName
                  WithArgs:(NSDictionary *)arguments
-               AndSuccess:(void (^)(id sucornil))sucornil
-               AndFailure:(void (^)(id failed))failornil;
+               AndSuccess:(void (^)(FHResponse *success))sucornil
+               AndFailure:(void (^)(FHResponse *failed))failornil;
 
 /** Create a new instance of FHAuthRequest class with the given auth policy id
 and execute it immediately with the success and failure blocks.
@@ -131,8 +131,8 @@ should be provided at this point (for example, LDAP).
 + (void)performAuthRequest:(NSString *)policyId
               WithUserName:(NSString *)username
               UserPassword:(NSString *)userpass
-                AndSuccess:(void (^)(id sucornil))sucornil
-                AndFailure:(void (^)(id failed))failornil;
+                AndSuccess:(void (^)(FHResponse *sucornil))sucornil
+                AndFailure:(void (^)(FHResponse *failed))failornil;
 
 /** Create a new instance of FHCloudRequest class and execute it immediately
 with the success and failure blocks.
@@ -152,8 +152,8 @@ function is failed
                  WithMethod:(NSString *)requestMethod
                  AndHeaders:(NSDictionary *)headers
                     AndArgs:(NSDictionary *)arguments
-                 AndSuccess:(void (^)(id success))sucornil
-                 AndFailure:(void (^)(id failed))failornil;
+                 AndSuccess:(void (^)(FHResponse *success))sucornil
+                 AndFailure:(void (^)(FHResponse *failed))failornil;
 
 /** Get the cloud host the app is communicating with.
 
@@ -192,8 +192,8 @@ or use the getDefaultParamsAsHeaders method to add them as HTTP request headers.
  @param failornil Block to be executed if the execution of the cloud side
  function is failed
  */
-+ (void)clearAuthSessionWithSuccess:(void (^)(id success))sucornil
-                         AndFailure:(void (^)(id failed))failornil;
++ (void)clearAuthSessionWithSuccess:(void (^)(FHResponse *success))sucornil
+                         AndFailure:(void (^)(FHResponse *failed))failornil;
 
 /**
  Verify the auth session to make sure it's still valid.

--- a/fh-ios-sdk/FH.m
+++ b/fh-ios-sdk/FH.m
@@ -32,7 +32,7 @@ static Reachability *reachability;
  initializeFH must be called before any other FH method can be used.
  If it is not called FH will throw an exception
  */
-+ (void)initWithSuccess:(void (^)(id success))sucornil AndFailure:(void (^)(id failed))failornil {
++ (void)initWithSuccess:(void (^)(FHResponse *success))sucornil AndFailure:(void (^)(FHResponse *failed))failornil {
     if (!initCalled) {
         [FH registerForNetworkReachabilityNotifications];
     }
@@ -181,8 +181,8 @@ static Reachability *reachability;
 
 + (void)performActRequest:(NSString *)funcName
                  WithArgs:(NSDictionary *)arguments
-               AndSuccess:(void (^)(id success))sucornil
-               AndFailure:(void (^)(id failed))failornil {
+               AndSuccess:(void (^)(FHResponse *success))sucornil
+               AndFailure:(void (^)(FHResponse *failed))failornil {
     FHActRequest *request = [self buildActRequest:funcName WithArgs:arguments];
     [request execAsyncWithSuccess:sucornil AndFailure:failornil];
 }
@@ -203,8 +203,8 @@ static Reachability *reachability;
 + (void)performAuthRequest:(NSString *)policyId
               WithUserName:(NSString *)username
               UserPassword:(NSString *)userpass
-                AndSuccess:(void (^)(id sucornil))sucornil
-                AndFailure:(void (^)(id failed))failornil {
+                AndSuccess:(void (^)(FHResponse *success))sucornil
+                AndFailure:(void (^)(FHResponse *failed))failornil {
     FHAuthRequest *auth = [self buildAuthRequest];
     [auth authWithPolicyId:policyId UserId:username Password:userpass];
     [auth execAsyncWithSuccess:sucornil AndFailure:failornil];
@@ -214,8 +214,8 @@ static Reachability *reachability;
                  WithMethod:(NSString *)requestMethod
                  AndHeaders:(NSDictionary *)headers
                     AndArgs:(NSDictionary *)arguments
-                 AndSuccess:(void (^)(id success))sucornil
-                 AndFailure:(void (^)(id failed))failornil {
+                 AndSuccess:(void (^)(FHResponse *success))sucornil
+                 AndFailure:(void (^)(FHResponse *failed))failornil {
     FHCloudRequest *cloudRequest =
         [self buildCloudRequest:path WithMethod:requestMethod AndHeaders:headers AndArgs:arguments];
     [cloudRequest execAsyncWithSuccess:sucornil AndFailure:failornil];
@@ -311,8 +311,8 @@ static Reachability *reachability;
     return nil != [FHDataManager read:SESSION_TOKEN_KEY];
 }
 
-+ (void)clearAuthSessionWithSuccess:(void (^)(id success))sucornil
-                         AndFailure:(void (^)(id failed))failornil {
++ (void)clearAuthSessionWithSuccess:(void (^)(FHResponse *success))sucornil
+                         AndFailure:(void (^)(FHResponse *failed))failornil {
     id session = [FHDataManager read:SESSION_TOKEN_KEY];
     if (nil != session) {
         [FHDataManager remove:SESSION_TOKEN_KEY];

--- a/fh-ios-sdk/FHAct.h
+++ b/fh-ios-sdk/FHAct.h
@@ -100,7 +100,7 @@ exectued.
 
 @see FHResponseDelegate
 */
-- (void)execWithSuccess:(void (^)(id success))sucornil AndFailure:(void (^)(id failed))failornil;
+- (void)execWithSuccess:(void (^)(FHResponse *success))sucornil AndFailure:(void (^)(FHResponse *failed))failornil;
 
 /** Excute the API request asynchronously with the given success and failure
 blocks.
@@ -115,7 +115,7 @@ the delegate's [FHResponseDelegate requestDidFailWithResponse:] will be
 exectued.
 @see FHResponseDelegate
 */
-- (void)execAsyncWithSuccess:(void (^)(id success))sucornil
-                  AndFailure:(void (^)(id failed))failornil;
+- (void)execAsyncWithSuccess:(void (^)(FHResponse *success))sucornil
+                  AndFailure:(void (^)(FHResponse *failed))failornil;
 
 @end

--- a/fh-ios-sdk/FHAct.m
+++ b/fh-ios-sdk/FHAct.m
@@ -56,18 +56,18 @@
     return [NSMutableDictionary dictionaryWithDictionary:[FH getDefaultParams]];
 }
 
-- (void)execWithSuccess:(void (^)(id success))sucornil AndFailure:(void (^)(id failed))failornil {
+- (void)execWithSuccess:(void (^)(FHResponse *success))sucornil AndFailure:(void (^)(FHResponse *failed))failornil {
     [self exec:FALSE WithSuccess:sucornil AndFailure:failornil];
 }
 
-- (void)execAsyncWithSuccess:(void (^)(id success))sucornil
-                  AndFailure:(void (^)(id failed))failornil {
+- (void)execAsyncWithSuccess:(void (^)(FHResponse *success))sucornil
+                  AndFailure:(void (^)(FHResponse *failed))failornil {
     [self exec:TRUE WithSuccess:sucornil AndFailure:failornil];
 }
 
 - (void)exec:(BOOL)pAsync
-    WithSuccess:(void (^)(id success))sucornil
-     AndFailure:(void (^)(id failed))failornil {
+    WithSuccess:(void (^)(FHResponse *success))sucornil
+     AndFailure:(void (^)(FHResponse *failed))failornil {
     _async = pAsync;
     [_httpClient sendRequest:self AndSuccess:sucornil AndFailure:failornil];
 }

--- a/fh-ios-sdk/FHAuthRequest.m
+++ b/fh-ios-sdk/FHAuthRequest.m
@@ -67,8 +67,8 @@
 }
 
 - (void)exec:(BOOL)pAsync
-    WithSuccess:(void (^)(id success))sucornil
-     AndFailure:(void (^)(id failed))failornil {
+    WithSuccess:(void (^)(FHResponse *success))sucornil
+     AndFailure:(void (^)(FHResponse *failed))failornil {
     _async = pAsync;
     void (^tmpSuccess)(FHResponse *) = ^(FHResponse *res) {
         NSDictionary *result = res.parsedResponse;

--- a/fh-ios-sdk/FHHttpClient.h
+++ b/fh-ios-sdk/FHHttpClient.h
@@ -19,7 +19,7 @@
 }
 
 - (void)sendRequest:(FHAct *)fhact
-         AndSuccess:(void (^)(id success))sucornil
-         AndFailure:(void (^)(id failed))failornil;
+         AndSuccess:(void (^)(FHResponse *success))sucornil
+         AndFailure:(void (^)(FHResponse *failed))failornil;
 
 @end

--- a/fh-ios-sdk/FHHttpClient.m
+++ b/fh-ios-sdk/FHHttpClient.m
@@ -22,8 +22,8 @@
 }
 
 - (void)sendRequest:(FHAct *)fhact
-         AndSuccess:(void (^)(id success))sucornil
-         AndFailure:(void (^)(id failed))failornil {
+         AndSuccess:(void (^)(FHResponse *success))sucornil
+         AndFailure:(void (^)(FHResponse *failed))failornil {
 #if NS_BLOCKS_AVAILABLE
     if (sucornil) {
         successHandler = [sucornil copy];

--- a/fh-ios-sdk/Sync/FHSyncClient.h
+++ b/fh-ios-sdk/Sync/FHSyncClient.h
@@ -6,7 +6,6 @@
 //
 
 #import "FH.h"
-#import "FHSyncClient.h"
 #import "FHSyncConfig.h"
 #import "FHSyncNotificationMessage.h"
 #import "FHSyncDelegate.h"
@@ -98,8 +97,8 @@
  @param failornil the failure callback function
  */
 - (void)listCollisionWithCallbacksForDataId:(NSString *)dataId
-                                 AndSuccess:(void (^)(id success))sucornil
-                                 AndFailure:(void (^)(id failed))failornil;
+                                 AndSuccess:(void (^)(FHResponse *success))sucornil
+                                 AndFailure:(void (^)(FHResponse *failed))failornil;
 
 /**
  Remove a collision with hash collisionHash for data set with id dataId
@@ -111,8 +110,8 @@
  */
 - (void)removeCollisionWithCallbacksForDataId:(NSString *)dataId
                                          hash:(NSString *)collisionHash
-                                   AndSuccess:(void (^)(id success))sucornil
-                                   AndFailure:(void (^)(id failed))failornil;
+                                   AndSuccess:(void (^)(FHResponse *success))sucornil
+                                   AndFailure:(void (^)(FHResponse *failed))failornil;
 
 /**
  Stop the sync service for data set with id dataId

--- a/fh-ios-sdk/Sync/FHSyncClient.m
+++ b/fh-ios-sdk/Sync/FHSyncClient.m
@@ -200,8 +200,8 @@
 }
 
 - (void)listCollisionWithCallbacksForDataId:(NSString *)dataId
-                                 AndSuccess:(void (^)(id success))sucornil
-                                 AndFailure:(void (^)(id failed))failornil {
+                                 AndSuccess:(void (^)(FHResponse *success))sucornil
+                                 AndFailure:(void (^)(FHResponse *failed))failornil {
     [FH performActRequest:dataId
                  WithArgs:@{
                      @"fn" : @"listCollisions"
@@ -212,8 +212,8 @@
 
 - (void)removeCollisionWithCallbacksForDataId:(NSString *)dataId
                                          hash:(NSString *)collisionHash
-                                   AndSuccess:(void (^)(id success))sucornil
-                                   AndFailure:(void (^)(id failed))failornil {
+                                   AndSuccess:(void (^)(FHResponse *success))sucornil
+                                   AndFailure:(void (^)(FHResponse *failed))failornil {
     [FH performActRequest:dataId
                  WithArgs:@{
                      @"fn" : @"removeCollisions",

--- a/fh-ios-sdk/Sync/FHSyncDataset.m
+++ b/fh-ios-sdk/Sync/FHSyncDataset.m
@@ -444,8 +444,8 @@
 }
 
 - (void)doCloudCall:(NSMutableDictionary *)params
-         AndSuccess:(void (^)(id success))sucornil
-         AndFailure:(void (^)(id failed))failornil {
+         AndSuccess:(void (^)(FHResponse *success))sucornil
+         AndFailure:(void (^)(FHResponse *failed))failornil {
     if (self.syncConfig.hasCustomSync) {
         [FH performActRequest:self.datasetId
                      WithArgs:params

--- a/fh-ios-sdkTests/MockFHHttpClient.m
+++ b/fh-ios-sdkTests/MockFHHttpClient.m
@@ -12,8 +12,8 @@
 @implementation MockFHHttpClient
 
 - (void)sendRequest:(FHAct *)fhact
-         AndSuccess:(void (^)(id success))sucornil
-         AndFailure:(void (^)(id failed))failornil {
+         AndSuccess:(void (^)(FHResponse *success))sucornil
+         AndFailure:(void (^)(FHResponse *failed))failornil {
     NSMutableDictionary *initRes = [NSMutableDictionary dictionary];
     NSMutableDictionary *authRes = [NSMutableDictionary dictionary];
     NSMutableDictionary *cloudRes = [NSMutableDictionary dictionary];


### PR DESCRIPTION
**Motivation**
Since ```FHResponse``` is used on the responses on the client demos and on the library itself, let's be specific on the signature instead of returning ids

**To test**
Build/Test should be sufficient.

@wei-lee mind to review?

