### PR TITLE
Added a check for null response (otherwise App crashes on SSL Handshake error)

### DIFF
--- a/fh-ios-sdk/Sync/FHSyncDataset.m
+++ b/fh-ios-sdk/Sync/FHSyncDataset.m
@@ -423,13 +423,15 @@ static NSString *const kAck = @"acknowledgements";
                     // will review the crashed
                     // records to see if we can determine their current state.
                     [self markInFlightAsCrashed];
-                    DLog(@"syncLoop failed : msg = %@", [[response parsedResponse] JSONString]);
+                    NSString* message = response?[[response parsedResponse] JSONString]: @"null response recieved";
+
+                    DLog(@"syncLoop failed : msg = %@", message);
                     [FHSyncUtils doNotifyWithDataId:self.datasetId
                                              config:self.syncConfig
                                                 uid:NULL
                                                code:SYNC_FAILED_MESSAGE
-                                            message:[[response parsedResponse] JSONString]];
-                    [self syncCompleteWithCode:[[response parsedResponse] JSONString]];
+                                            message:message];
+                    [self syncCompleteWithCode:message];
                 }];
         }
         @catch (NSException *ex) {


### PR DESCRIPTION
In `FHSyncDataset.m`, and specifically the `startSyncTask:` method, we get a null response when there is an SSL Handshake error. Trying to pass a JSONString of the null response into `FHSyncUtils.m` results in the app crashing. This PR checks for a null response, and provides a message for `FHSyncUtils.m` to use.

Log example:
https://gist.github.com/antiguab/4192fe949878c605e69d