### PR TITLE
ensure we are loading from the main bundle

### DIFF
--- a/fh-ios-sdk/FHConfig.m
+++ b/fh-ios-sdk/FHConfig.m
@@ -21,7 +21,7 @@
     self = [super init];
     if (self) {
         NSString *path =
-            [[NSBundle bundleForClass:[self class]] pathForResource:@"fhconfig" ofType:@"plist"];
+            [[NSBundle mainBundle] pathForResource:@"fhconfig" ofType:@"plist"];
         if (path) {
             self.properties = [NSMutableDictionary dictionaryWithContentsOfFile:path];
         } else {


### PR DESCRIPTION
The config file, fhconfig.plist, resides in the Application's bundle and not the framework's bundle. Accordingly, we should look in the mainBundle and not the bundleforClass.