### PR TITLE
Fh 1659.set enable bitcode=true

### DIFF
--- a/FH.podspec
+++ b/FH.podspec
@@ -14,5 +14,5 @@ Pod::Spec.new do |s|
   s.libraries = 'xml2', 'z'
   s.dependency 'ASIHTTPRequest/Core', '1.8.2'
   s.dependency 'Reachability', '3.2'
-  s.dependency 'AeroGear-Push', '1.1.0-beta.2'
+  s.dependency 'AeroGear-Push', '1.1.1'
 end

--- a/Podfile
+++ b/Podfile
@@ -4,10 +4,10 @@ xcodeproj 'fh-ios-sdk.xcodeproj'
 platform :ios, '7.0'
 
 pod 'ASIHTTPRequest/Core', '1.8.2'
-pod 'AeroGear-Push', '1.1.0-beta.2'
+pod 'AeroGear-Push', '1.1.1'
 
 target 'FHTests', :exclusive => true do
     pod 'ASIHTTPRequest/Core', '1.8.2' 
-    pod 'AeroGear-Push', '1.1.0-beta.2'
+    pod 'AeroGear-Push', '1.1.1'
     pod 'Nocilla', '0.10.0'
 end

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,17 +1,17 @@
 PODS:
-  - AeroGear-Push (1.1.0-beta.2)
+  - AeroGear-Push (1.1.1)
   - ASIHTTPRequest/Core (1.8.2):
     - Reachability
   - Nocilla (0.10.0)
   - Reachability (3.2)
 
 DEPENDENCIES:
-  - AeroGear-Push (= 1.1.0-beta.2)
+  - AeroGear-Push (= 1.1.1)
   - ASIHTTPRequest/Core (= 1.8.2)
   - Nocilla (= 0.10.0)
 
 SPEC CHECKSUMS:
-  AeroGear-Push: f2a5b604c56be7b57e8b34c7fabd4f18fb425899
+  AeroGear-Push: 0d4dd12e6311f1231e2517a8597ca199bd1b8683
   ASIHTTPRequest: ec013992946676b7978dcbde6396d57312d21db4
   Nocilla: ae0a2b05f3087b473624ac2b25903695df51246a
   Reachability: 33e18b67625424e47b6cde6d202dce689ad7af96

--- a/fh-ios-sdk.xcodeproj/project.pbxproj
+++ b/fh-ios-sdk.xcodeproj/project.pbxproj
@@ -769,6 +769,7 @@
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				DEAD_CODE_STRIPPING = NO;
 				DSTROOT = /tmp/FH.dst;
+				ENABLE_BITCODE = YES;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "fh-ios-sdk/fh-ios-sdk-Prefix.pch";
 				HEADER_SEARCH_PATHS = (
@@ -795,6 +796,7 @@
 				COPY_PHASE_STRIP = NO;
 				DEAD_CODE_STRIPPING = NO;
 				DSTROOT = /tmp/FH.dst;
+				ENABLE_BITCODE = YES;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "fh-ios-sdk/fh-ios-sdk-Prefix.pch";
 				HEADER_SEARCH_PATHS = (


### PR DESCRIPTION
Update to latest version of AG push (built with enable bitcode = true) and build FH sdk with this default iOS9 option.