### PR TITLE
Raise SYNC_COMPLETE only when either syncquest or syncRecords sucessf…

### DIFF
--- a/fh-ios-sdk/Sync/FHSyncDataset.m
+++ b/fh-ios-sdk/Sync/FHSyncDataset.m
@@ -559,9 +559,8 @@ static NSString *const kUIDMapping = @"uidMapping";
         [self syncRecords];
     } else {
         DLog(@"Local dataset up to date");
+        [self syncCompleteWithCode:@"online"];
     }
-
-    [self syncCompleteWithCode:@"online"];
 }
 
 - (void) checkUidChanges:(NSDictionary*) appliedUpdates


### PR DESCRIPTION
…ully completed
@wei-lee As discussed in RHMAP-2703, to comply with JS sdk implementation, raised SYNC_COMPLETE event only when either syncRecords successfully completed