### PR TITLE
Rhmap 2737.remove.sync.dead.code.on.reset.dataset

### DIFF
--- a/demos/FHSyncTestApp/Podfile.lock
+++ b/demos/FHSyncTestApp/Podfile.lock
@@ -1,6 +1,6 @@
 PODS:
   - AeroGear-Push (1.1.1)
-  - FH (2.2.19):
+  - FH (3.0.0-beta1):
     - AeroGear-Push (= 1.1.1)
     - Reachability (= 3.2)
   - Reachability (3.2)
@@ -10,11 +10,11 @@ DEPENDENCIES:
 
 EXTERNAL SOURCES:
   FH:
-    :path: "../../"
+    :path: ../../
 
 SPEC CHECKSUMS:
   AeroGear-Push: 0d4dd12e6311f1231e2517a8597ca199bd1b8683
-  FH: ec5574a3a0638abaf97ab0441bdd39cb6a5e4f96
+  FH: 917138aa557a7f45206365d9f75269ddef46481c
   Reachability: 33e18b67625424e47b6cde6d202dce689ad7af96
 
 COCOAPODS: 0.39.0

--- a/fh-ios-sdk/Sync/FHSyncDataset.m
+++ b/fh-ios-sdk/Sync/FHSyncDataset.m
@@ -536,13 +536,6 @@ static NSString *const kUIDMapping = @"uidMapping";
     
     [self updateMetaFromNewData:resData];
 
-//    BOOL hasRecords = NO;
-//    if (resData[@"records"]) {
-//        // Full Dataset returned
-//        hasRecords = YES;
-//        [self resetDataRecords:resData];
-//    }
-
     if (resData[@"updates"]) {
         NSMutableArray *ack = [NSMutableArray array];
         NSDictionary *updates = resData[@"updates"];
@@ -763,24 +756,6 @@ static NSString *const kUIDMapping = @"uidMapping";
         DLog(@"SyncRecords result after pending removed = %@", resData);
     }];
 }
-
-//- (void)resetDataRecords:(NSDictionary *)resData {
-//    NSDictionary *records = resData[@"records"];
-//    NSMutableDictionary *allRecords = [NSMutableDictionary dictionary];
-//    [records enumerateKeysAndObjectsUsingBlock:^(id key, id obj, BOOL *stop) {
-//        NSDictionary *data = (NSDictionary *)obj;
-//        FHSyncDataRecord *record = [[FHSyncDataRecord alloc] initWithData:data];
-//        allRecords[key] = record;
-//    }];
-//
-//    self.dataRecords = allRecords;
-//    self.hashValue = resData[@"hash"];
-//    [FHSyncUtils doNotifyWithDataId:self.datasetId
-//                             config:self.syncConfig
-//                                uid:self.hashValue
-//                               code:DELTA_RECEIVED_MESSAGE
-//                            message:@"full dataset"];
-//}
 
 - (void)processUpdates:(NSDictionary *)updates
           notification:(NSString *)notifcation

--- a/fh-ios-sdk/Sync/FHSyncDataset.m
+++ b/fh-ios-sdk/Sync/FHSyncDataset.m
@@ -536,12 +536,12 @@ static NSString *const kUIDMapping = @"uidMapping";
     
     [self updateMetaFromNewData:resData];
 
-    BOOL hasRecords = NO;
-    if (resData[@"records"]) {
-        // Full Dataset returned
-        hasRecords = YES;
-        [self resetDataRecords:resData];
-    }
+//    BOOL hasRecords = NO;
+//    if (resData[@"records"]) {
+//        // Full Dataset returned
+//        hasRecords = YES;
+//        [self resetDataRecords:resData];
+//    }
 
     if (resData[@"updates"]) {
         NSMutableArray *ack = [NSMutableArray array];
@@ -560,7 +560,7 @@ static NSString *const kUIDMapping = @"uidMapping";
         self.acknowledgements = ack;
     }
 
-    if (!hasRecords && resData[@"hash"] && ![resData[@"hash"] isEqualToString:self.hashValue]) {
+    if (resData[@"hash"] && ![resData[@"hash"] isEqualToString:self.hashValue]) {
         NSString *remoteHash = resData[@"hash"];
         DLog(@"Local dataset stale - syncing records :: local hash= %@ - remoteHash = %@",
               self.hashValue, remoteHash);
@@ -764,23 +764,23 @@ static NSString *const kUIDMapping = @"uidMapping";
     }];
 }
 
-- (void)resetDataRecords:(NSDictionary *)resData {
-    NSDictionary *records = resData[@"records"];
-    NSMutableDictionary *allRecords = [NSMutableDictionary dictionary];
-    [records enumerateKeysAndObjectsUsingBlock:^(id key, id obj, BOOL *stop) {
-        NSDictionary *data = (NSDictionary *)obj;
-        FHSyncDataRecord *record = [[FHSyncDataRecord alloc] initWithData:data];
-        allRecords[key] = record;
-    }];
-
-    self.dataRecords = allRecords;
-    self.hashValue = resData[@"hash"];
-    [FHSyncUtils doNotifyWithDataId:self.datasetId
-                             config:self.syncConfig
-                                uid:self.hashValue
-                               code:DELTA_RECEIVED_MESSAGE
-                            message:@"full dataset"];
-}
+//- (void)resetDataRecords:(NSDictionary *)resData {
+//    NSDictionary *records = resData[@"records"];
+//    NSMutableDictionary *allRecords = [NSMutableDictionary dictionary];
+//    [records enumerateKeysAndObjectsUsingBlock:^(id key, id obj, BOOL *stop) {
+//        NSDictionary *data = (NSDictionary *)obj;
+//        FHSyncDataRecord *record = [[FHSyncDataRecord alloc] initWithData:data];
+//        allRecords[key] = record;
+//    }];
+//
+//    self.dataRecords = allRecords;
+//    self.hashValue = resData[@"hash"];
+//    [FHSyncUtils doNotifyWithDataId:self.datasetId
+//                             config:self.syncConfig
+//                                uid:self.hashValue
+//                               code:DELTA_RECEIVED_MESSAGE
+//                            message:@"full dataset"];
+//}
 
 - (void)processUpdates:(NSDictionary *)updates
           notification:(NSString *)notifcation


### PR DESCRIPTION
@wei-lee as you asked i removed the processing done when backend return "records" as it's not the case anymore. 
Less is more. No dead code.
did i miss anything else that would be obvious to you?