### PR TITLE
Add oauth token in fh.cloud as x-fh-sessiontoken header

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,11 @@
 language: objective-c
-osx_image: xcode7
+osx_image: xcode7.3
 xcode_workspace: fh-ios-sdk.xcworkspace
 xcode_scheme: FH
 xcode_sdk: iphonesimulator
 
 before_install:
-    - gem install cocoapods -v '0.39.0' obcd slather -N --no-rdoc --no-ri --no-document --quiet
+    - gem install cocoapods -v '0.39.0' -N --no-rdoc --no-ri --no-document --quiet
 
 notifications:
   irc: "irc.freenode.org#feedhenry"

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ xcode_scheme: FH
 xcode_sdk: iphonesimulator
 
 before_install:
-    - gem install cocoapods - v '0.39.0' obcd slather -N --no-rdoc --no-ri --no-document --quiet
+    - gem install cocoapods -v '0.39.0' obcd slather -N --no-rdoc --no-ri --no-document --quiet
 
 notifications:
   irc: "irc.freenode.org#feedhenry"

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ xcode_scheme: FH
 xcode_sdk: iphonesimulator
 
 before_install:
-    - gem install cocoapods obcd slather -N --no-rdoc --no-ri --no-document --quiet
+    - gem install cocoapods - v '0.39.0' obcd slather -N --no-rdoc --no-ri --no-document --quiet
 
 notifications:
   irc: "irc.freenode.org#feedhenry"

--- a/fh-ios-sdk/Cloud/FHAuthRequest.m
+++ b/fh-ios-sdk/Cloud/FHAuthRequest.m
@@ -86,6 +86,13 @@ static NSString *const kAuthPath = @"box/srv/1.1/admin/authpolicy/auth";
             NSString *oauthUrl = [result valueForKey:@"url"];
             if (oauthUrl && self.parentViewController != nil) {
                 void (^complete)(FHResponse *) = ^(FHResponse *resp) {
+                    // Put oauth token dataManager to later put in in fh.cloud's headers as key "x-fh-sessiontoken"
+                    NSDictionary* authResponse = resp.parsedResponse[@"authResponse"];
+                    NSString* authToken = authResponse[@"authToken"];
+                    DLog(@"Auth token: %@", authToken);
+                    if (authToken) {
+                        [FHDataManager save:SESSION_TOKEN_KEY withObject:authToken];
+                    }
                     if (sucornil) {
                         sucornil(resp);
                     } else {


### PR DESCRIPTION
@secondsun @danielpassos 
In the case of oauth2 policyId (see set up here: https://github.com/feedhenry-templates/oauth-ios-app#set-up-google-provider) the sessionToken were not filled in with oauth token, as a result subsequent fh.cloud call does not have oauth token in x-fh-sessiontoken header.

Question: in fh-andrdoi-sdk does that line: https://github.com/feedhenry/fh-android-sdk/blob/master/fh-android-sdk/src/main/java/com/feedhenry/sdk/api/FHAuthRequest.java#L229-L231
also save the token in  case of oauth2 policyId?

To test:
1. use [oauth-ios-app](https://github.com/feedhenry-templates/oauth-ios-app), in Podfile point to this PR branch
2. authenticate with google
3. do a cloud call, using a http snipper tools (like Charles) check  x-fh-sessiontoken header is set.