### PR TITLE
Fixed support for coveralls.io

### DIFF
--- a/.slather.yml
+++ b/.slather.yml
@@ -1,4 +1,11 @@
-ci_service: travis_ci
 coverage_service: coveralls
+workspace: fh-ios-sdk.xcworkspace
 xcodeproj: fh-ios-sdk.xcodeproj
+scheme: FH
 source_directory: fh-ios-sdk
+build_directory: /Users/travis/Library/Developer/Xcode/DerivedData/
+binary_basename: FH
+ignore:
+  - ../*
+  - Pods/*
+  - fh-ios-sdkTests/*

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,11 @@
 language: objective-c
 osx_image: xcode7.3
-xcode_workspace: fh-ios-sdk.xcworkspace
-xcode_scheme: FH
-xcode_sdk: iphonesimulator
 
 before_install:
-    - gem install cocoapods obcd slather -N --no-rdoc --no-ri --no-document --quiet
+  - gem install cocoapods obcd slather --no-document --quiet
+
+script:
+  - xcodebuild clean build test -workspace fh-ios-sdk.xcworkspace -scheme FH -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 6' GCC_INSTRUMENT_PROGRAM_FLOW_ARCS=YES GCC_GENERATE_TEST_COVERAGE_FILES=YES
 
 notifications:
   irc: "irc.freenode.org#feedhenry"
@@ -13,4 +13,6 @@ notifications:
 branches:
   only:
     - master
-after_success: slather
+
+after_success:
+  - slather

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-# FeedHenry iOS SDK 
+# FeedHenry iOS SDK
 
-[![Build Status](https://travis-ci.org/feedhenry/fh-ios-sdk.png)](https://travis-ci.org/feedhenry/fh-ios-sdk)
-[![Coverage Status](https://coveralls.io/repos/feedhenry/fh-ios-sdk/badge.svg?branch=master&service=github)](https://coveralls.io/github/feedhenry/fh-ios-sdk?branch=master)
+[![Build Status](https://travis-ci.org/feedhenry/fh-ios-sdk.svg?branch=master)](https://travis-ci.org/feedhenry/fh-ios-sdk)
+[![Coverage Status](https://coveralls.io/repos/github/feedhenry/fh-ios-sdk/badge.svg?branch=master)](https://coveralls.io/github/feedhenry/fh-ios-sdk?branch=master)
 [![CocoaPods Compatible](https://img.shields.io/cocoapods/v/FH.svg)](https://img.shields.io/cocoapods/v/FH.svg)
 [![Platform](https://img.shields.io/cocoapods/p/FH.svg?style=flat)](http://cocoadocs.org/docsets/FH)
 
@@ -29,10 +29,10 @@ Then, install cocoapods dependencies.
 pod install
 open fh-ios-sdk.xcworkspace
 ```
-**Note:** Do not open `fh-ios-sdk.xcodeproj`, work with xcworkspace ensures both the iOS SDK project and the cocoapods dependencies are included in Xcode. 
+**Note:** Do not open `fh-ios-sdk.xcodeproj`, work with xcworkspace ensures both the iOS SDK project and the cocoapods dependencies are included in Xcode.
 
 ## Running Tests
-Tests can be run in Xcode by navigating to Product -> Test. 
+Tests can be run in Xcode by navigating to Product -> Test.
 
 ## Working with templates app
 
@@ -87,4 +87,3 @@ This will produce two files in the ``Releases-{version}`` directory.  You can th
 ### c) Generate API Documentation
 
 To generate API documentation and sync with the [GitHub pages placeholder](http://feedhenry.github.io/fh-ios-sdk/FH/docset/Contents/Resources/Documents/index.html), switch to ['gh-pages'](https://github.com/feedhenry/fh-ios-sdk/tree/gh-pages) branch and follow the instructions there.
-


### PR DESCRIPTION
# Motivation

https://issues.jboss.org/browse/FH-2822
Code coverage reports are not being created at the moment. The last code coverage update is from January 2016.
# Changed

Fixed travis and slather config.
